### PR TITLE
Add scalable hello world CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -482,3 +482,12 @@ $RECYCLE.BIN/
 
 # Vim temporary swap files
 *.swp
+
+# Python
+__pycache__/
+*.py[cod]
+*.so
+build/
+dist/
+*.egg-info/
+.eggs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,4 @@ branch naming or stacking are enforced here.
 
 - ipsum lorem
 - 4ba222d7359c3ca373253bef5445def90f75ed4b
+- 00caa51c44fd72f5dead2da8c316d725a8fdc85f

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include LICENSE

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# obk CLI
+
+A scalable hello world command-line tool built with [Typer](https://typer.tiangolo.com/).

--- a/prompts/07/28/20250728T141621-0400.md
+++ b/prompts/07/28/20250728T141621-0400.md
@@ -87,6 +87,7 @@ This table lists the essential components produced by the OBK scaffold process. 
 
 * We have coupons for egg rolls
 * Added manual changelog tests to `changelog-automation-for-python.md`
+* Implemented a Typer-based `obk` CLI with tests and packaging
 
 
 </gsl-notes>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["hatchling>=1.24"]
+build-backend = "hatchling.build"
+
+[project]
+name = "obk-cli"
+version = "0.1.0"
+description = "A scalable hello-world CLI starter."
+authors = [{ name = "Your Name", email = "you@example.com" }]
+readme = "README.md"
+requires-python = ">=3.9"
+
+dependencies = ["typer[all]>=0.12"]
+
+[project.scripts]
+obk = "obk.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/obk"]
+
+[tool.hatch.envs.default]
+dependencies = [
+  "pytest",
+  "ruff",
+  "black",
+]
+
+[tool.pytest.ini_options]
+addopts = "-q"

--- a/src/obk/__init__.py
+++ b/src/obk/__init__.py
@@ -1,0 +1,2 @@
+__all__ = ["__version__", "cli"]
+__version__ = "0.1.0"

--- a/src/obk/__main__.py
+++ b/src/obk/__main__.py
@@ -1,0 +1,4 @@
+from .cli import app
+
+if __name__ == "__main__":
+    app()

--- a/src/obk/cli.py
+++ b/src/obk/cli.py
@@ -1,0 +1,8 @@
+from typer import Typer, echo
+
+app = Typer(add_completion=False)
+
+@app.command()
+def hello(name: str = "world"):
+    """A stub command that prints a friendly greeting."""
+    echo(f"Hello, {name}!")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,14 @@
+from typer.testing import CliRunner
+from obk.cli import app
+
+runner = CliRunner()
+
+def test_hello_default():
+    result = runner.invoke(app)
+    assert result.exit_code == 0
+    assert "Hello, world!" in result.output
+
+def test_hello_custom():
+    result = runner.invoke(app, ["--name", "Alice"])
+    assert result.exit_code == 0
+    assert "Hello, Alice!" in result.output


### PR DESCRIPTION
## Summary
- implement a Typer-based CLI following the article
- add packaging via pyproject and MANIFEST
- add tests for CLI
- update notes in prompt 20250728T141621-0400
- track commit in AGENTS.md

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688809e4fa8c8323846678a126f6abf1