### PR TITLE
Run commit lint and release draft on self-hosted

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   commitlint:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - uses: wagoid/commitlint-github-action@v6

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   update_release_draft:
     if: github.event.pull_request.merged == true # should prevent duplicate drafts
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: release-drafter/release-drafter@v6
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,4 @@ branch naming or stacking are enforced here.
 - 00caa51c44fd72f5dead2da8c316d725a8fdc85f
 - f35652058bed6794dd00d6432f2ae81a6980ff07
 - ea1a04aef0e11407db1d94d0f1692ea0bfa2848b
+- bea7eeef689a3ac7863217007d71fc0fb4a230c4

--- a/prompts/07/28/20250728T141621-0400.md
+++ b/prompts/07/28/20250728T141621-0400.md
@@ -103,7 +103,7 @@ This table lists the essential components produced by the OBK scaffold process. 
 #### Continuous Integration
 
 - 4.1 Pushes to the `work` branch trigger GitHub Actions.
-- 4.2 The workflow installs dependencies and runs `pytest` on Ubuntu.
+- 4.2 The workflow installs dependencies and runs `pytest` on self-hosted runners.
 
 </gsl-workflow-steps>
 <gsl-next-steps>


### PR DESCRIPTION
## Summary
- switch commitlint workflow to `self-hosted`
- switch release-drafter workflow to `self-hosted`
- note the change in the July prompt
- track the new commit in `AGENTS.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68883b05fd6483238098aa6172df7079