### PR TITLE
test(ci): skip commitlint when previous commit SHA is invalid

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -41,5 +41,10 @@ jobs:
         run: |
           echo "From: ${{ github.event.before }}"
           echo "To:   ${{ github.sha }}"
-          commitlint --from ${{ github.event.before }} --to ${{ github.sha }} --config commitlint.config.js
+          if [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
+            echo "No previous commit detected, skipping commitlint."
+            exit 0
+          else
+            commitlint --from ${{ github.event.before }} --to ${{ github.sha }} --config commitlint.config.js
+          fi
         working-directory: ${{ github.workspace }}


### PR DESCRIPTION
Skips commitlint if GITHUB_EVENT_BEFORE is zeroed, preventing failures on first or forced pushes.