### PR TITLE
Add CLI error handling and global logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ This repository uses prompts to document and trace development tasks. Prompts ar
 ## Prompts to Update
 
 - <gsl-prompt-id>N/A</gsl-prompt-id>
+- <gsl-prompt-id>20250729T145215-0400</gsl-prompt-id>
 
 Agents MUST automatically add any prompt files whose ID includes today's date
 (formatted as `YYYYMMDD`) to the list above. This ensures newly generated
@@ -48,3 +49,4 @@ branch naming or stacking are enforced here.
 - f35652058bed6794dd00d6432f2ae81a6980ff07
 - ea1a04aef0e11407db1d94d0f1692ea0bfa2848b
 - bea7eeef689a3ac7863217007d71fc0fb4a230c4
+- 8fb044dd0e01be9a7ca426966341573a3bfc0aed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,12 @@ This repository uses prompts to document and trace development tasks. Prompts ar
 
 ## Prompts to Update
 
-- <gsl-prompt-id>N/A</gsl-prompt-id>
-- <gsl-prompt-id>20250729T145215-0400</gsl-prompt-id>
+- <gsl-prompt-id>20250729T145215</gsl-prompt-id>
+
 
 Agents MUST automatically add any prompt files whose ID includes today's date
 (formatted as `YYYYMMDD`) to the list above. This ensures newly generated
-prompts from the current day are always updated without manual intervention.
+prompts from the current day are always updated with minimal manual intervention.
 
 ## Workflow for Agents
 
@@ -17,21 +17,6 @@ prompts from the current day are always updated without manual intervention.
 2. Run `python scripts/get_prompt_id.py -t UTC` to verify the prompt ID tool works and to normalize timestamps across environments.
 3. Commit the changes and open a pull request describing the modifications.
 
-## Commit Tracking
-
-Agents MUST track which commits have been documented in the prompt with ID
-<gsl-prompt-id>N/A</gsl-prompt-id>. After updating the prompt to describe a commit, append
-that commit hash to the **Documented Commits** list below. To discover
-undocumented commits, compare the hashes in this list with `git log --pretty=%H`.
-Only commits not present in the list require prompt updates. In addition,
-agents **MUST** limit their search to commits whose commit date matches the
-current day. The search should be performed using UTC to avoid timezone
-discrepancies when the agent runs from different regions. This prevents
-documenting stale changes when the agent runs on a later date.
-
-When scanning for same-day prompt files, list those prompt IDs alongside the
-commit hashes they document. This keeps a direct record of which prompt was
-updated for each commit.
 
 ### Branch Management
 
@@ -40,13 +25,3 @@ branch that depends on another, make at least one commit on the new branch
 before opening the next branch in the stack. This preserves the intended branch
 order in tools that visualize history. Apart from this, no additional rules on
 branch naming or stacking are enforced here.
-
-## Documented Commits
-
-- ipsum lorem
-- 4ba222d7359c3ca373253bef5445def90f75ed4b
-- 00caa51c44fd72f5dead2da8c316d725a8fdc85f
-- f35652058bed6794dd00d6432f2ae81a6980ff07
-- ea1a04aef0e11407db1d94d0f1692ea0bfa2848b
-- bea7eeef689a3ac7863217007d71fc0fb4a230c4
-- 8fb044dd0e01be9a7ca426966341573a3bfc0aed

--- a/prompts/07/29/20250729T145215-0400.md
+++ b/prompts/07/29/20250729T145215-0400.md
@@ -69,6 +69,10 @@ This table lists the essential components produced by the OBK scaffold process. 
 ## 6. Tests
 
 <gsl-test id="T1">TBD</gsl-test>
+<gsl-test id="T2">Running `obk divide 4 2` prints "2.0"</gsl-test>
+<gsl-test id="T3">Running `obk divide 1 0` exits with code 2 and prints an error message</gsl-test>
+<gsl-test id="T4">Running `obk fail` exits with code 1 and prints a fatal error message</gsl-test>
+<gsl-test id="T5">Running `python -m obk divide 4 2` prints "2.0"</gsl-test>
 
 
 </gsl-tdd>

--- a/prompts/07/29/20250729T145215-0400.md
+++ b/prompts/07/29/20250729T145215-0400.md
@@ -17,7 +17,7 @@ Note: This GSL document uses XML-like section tags as containers, but the conten
 
 ## 1.  Purpose
 
-Ensure the obk CLI as a robust unit testing framework and strategy.   </gsl-purpose>
+Ensure the obk CLI as a robust error handling strategy.   </gsl-purpose>
 
 <gsl-key-input-artifacts>
 
@@ -40,7 +40,10 @@ This table lists the essential components produced by the OBK scaffold process. 
 
 | Output Component | Description / Notes |
 | --- | --- |
-| TBD |  |
+| Custom Exceptions |  new CLI commands like “divide” and “fail,” divide-by-zero and fatal failures
+| Global exception hook |  |
+| Logging configuration |  |
+
 
 
 </gsl-output-components>
@@ -68,13 +71,33 @@ This table lists the essential components produced by the OBK scaffold process. 
 
 ## 6. Tests
 
-<gsl-test id="T1">TBD</gsl-test>
-<gsl-test id="T2">Running `obk divide 4 2` prints "2.0"</gsl-test>
-<gsl-test id="T3">Running `obk divide 1 0` exits with code 2 and prints an error message</gsl-test>
-<gsl-test id="T4">Running `obk fail` exits with code 1 and prints a fatal error message</gsl-test>
-<gsl-test id="T5">Running `python -m obk divide 4 2` prints "2.0"</gsl-test>
+<gsl-test id="T1">
 
+- T1: Test logging
 
+    ```powershell
+    obk divide 4 2                  # creates or appends to obk.log by default
+    obk --logfile my.log divide 4 2 # specify a custom log file
+    obk divide 1 0                  # writes an error to the log and exits with code 2
+    obk fail                        # writes a fatal error to the log and exits with code 1
+    python -m obk divide 4 2        # module invocation
+    ```
+</gsl-test>
+<gsl-test id="T2">
+
+- T2: Running `obk divide 4 2` prints "2.0"</gsl-test>
+
+<gsl-test id="T3">
+
+- T3: Running `obk divide 1 0` exits with code 2 and prints an error message</gsl-test>
+
+<gsl-test id="T4">
+
+- T4: Running `obk fail` exits with code 1 and prints a fatal error message</gsl-test>
+
+<gsl-test id="T5">
+
+- T5: Running `python -m obk divide 4 2` prints "2.0"</gsl-test>
 </gsl-tdd>
 
 <gsl-notes>
@@ -82,8 +105,7 @@ This table lists the essential components produced by the OBK scaffold process. 
 ## 7.  Notes
 
 
-* Adjusting unit testing strategy around a DI solution is out of the scope of this prompt. It will be addressed in a new prompt at a future date (after incorporating a DI solution). 
-
+* There was some initial confusion in doc originally meant for unit testing framework feature. Removed unit testing framework feature references. 
 
 </gsl-notes>
 

--- a/prompts/07/29/20250729T145215-0400.md
+++ b/prompts/07/29/20250729T145215-0400.md
@@ -3,7 +3,7 @@
 
 <gsl-header>
 
-# Hello World Scaffold
+# OBK Error Handling Strategy
 
 </gsl-header>
 

--- a/src/obk/cli.py
+++ b/src/obk/cli.py
@@ -3,24 +3,88 @@
 from __future__ import annotations
 
 import argparse
+import logging
+import sys
+from pathlib import Path
+
+
+class ObkError(Exception):
+    """Base exception for the obk CLI."""
+
+
+class CalculationError(ObkError):
+    """Raised when a calculation cannot be performed."""
 
 
 def _cmd_hello_world(_: argparse.Namespace) -> None:
     print("hello world")
 
 
+def _cmd_divide(args: argparse.Namespace) -> None:
+    if args.b == 0:
+        raise CalculationError("Cannot divide by zero")
+    result = args.a / args.b
+    print(result)
+
+
+def _cmd_fail(_: argparse.Namespace) -> None:
+    raise RuntimeError("boom")
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="obk")
+    parser.add_argument(
+        "--logfile",
+        type=Path,
+        default=Path("obk.log"),
+        help="Path to log file",
+    )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     hello_parser = subparsers.add_parser(
         "hello-world", help="Print hello world", description="Print hello world"
     )
     hello_parser.set_defaults(func=_cmd_hello_world)
+
+    divide_parser = subparsers.add_parser(
+        "divide", help="Divide two numbers", description="Divide A by B"
+    )
+    divide_parser.add_argument("a", type=float)
+    divide_parser.add_argument("b", type=float)
+    divide_parser.set_defaults(func=_cmd_divide)
+
+    fail_parser = subparsers.add_parser(
+        "fail", help="Trigger an unhandled exception", description="Fail hard"
+    )
+    fail_parser.set_defaults(func=_cmd_fail)
     return parser
 
 
+def _setup_logging(logfile: Path) -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+        handlers=[
+            logging.FileHandler(logfile, encoding="utf-8"),
+            logging.StreamHandler(sys.stdout),
+        ],
+    )
+
+
+def _global_excepthook(exc_type, exc_value, exc_tb) -> None:
+    logging.critical("Uncaught exception", exc_info=(exc_type, exc_value, exc_tb))
+    print("[FATAL] Unexpected crash, see log", file=sys.stderr)
+    sys.exit(1)
+
+
 def main(argv: list[str] | None = None) -> None:
+    sys.excepthook = _global_excepthook
     parser = build_parser()
     args = parser.parse_args(argv)
-    args.func(args)
+    _setup_logging(args.logfile)
+    try:
+        args.func(args)
+    except ObkError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        logging.getLogger(__name__).exception("Domain error")
+        sys.exit(2)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,44 +3,57 @@ import subprocess
 import sys
 from pathlib import Path
 
+
+def run_cli(args, *, cwd=None):
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    result = subprocess.run(
+        [sys.executable, "-m", "obk", *args],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        env=env,
+    )
+    return result
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 
 def test_hello_world():
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
-    result = subprocess.run(
-        [sys.executable, "-m", "obk", "hello-world"],
-        capture_output=True,
-        text=True,
-        check=True,
-        env=env,
-    )
+    result = run_cli(["hello-world"])
+    assert result.returncode == 0
     assert result.stdout.strip() == "hello world"
 
 
 def test_help():
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
-    result = subprocess.run(
-        [sys.executable, "-m", "obk", "hello-world", "-h"],
-        capture_output=True,
-        text=True,
-        check=True,
-        env=env,
-    )
+    result = run_cli(["hello-world", "-h"])
+    assert result.returncode == 0
     assert "Print hello world" in result.stdout
 
 
 def test_entrypoint_any_directory(tmp_path):
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
-    result = subprocess.run(
-        [sys.executable, "-m", "obk", "hello-world"],
-        capture_output=True,
-        text=True,
-        check=True,
-        cwd=tmp_path,
-        env=env,
-    )
+    result = run_cli(["hello-world"], cwd=tmp_path)
+    assert result.returncode == 0
     assert result.stdout.strip() == "hello world"
+
+
+def test_divide_success():
+    result = run_cli(["divide", "4", "2"])
+    assert result.returncode == 0
+    assert result.stdout.strip() == "2.0"
+
+
+def test_divide_zero_error(tmp_path):
+    log = tmp_path / "obk.log"
+    result = run_cli(["--logfile", str(log), "divide", "1", "0"])
+    assert result.returncode == 2
+    assert "[ERROR] Cannot divide by zero" in result.stderr
+    assert log.exists() and log.read_text()
+
+
+def test_fail_unhandled_exception(tmp_path):
+    log = tmp_path / "fail.log"
+    result = run_cli(["--logfile", str(log), "fail"])
+    assert result.returncode == 1
+    assert "[FATAL] Unexpected crash, see log" in result.stderr
+    assert log.exists() and log.read_text()


### PR DESCRIPTION
## Summary
- implement divide and fail commands with custom error types
- configure logging and a global exception handler
- update CLI tests for new commands
- add manual tests to 20250729 prompt
- update AGENTS record

## Testing
- `pytest -q`
- `python scripts/get_prompt_id.py -t UTC`

------
https://chatgpt.com/codex/tasks/task_e_68891dfcbbf88323b7864d41878a4f36