### PR TITLE
Add divide command with logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ This repository uses prompts to document and trace development tasks. Prompts ar
 ## Prompts to Update
 
 - <gsl-prompt-id>N/A</gsl-prompt-id>
+- <gsl-prompt-id>20250729T145215-0400</gsl-prompt-id>
 
 Agents MUST automatically add any prompt files whose ID includes today's date
 (formatted as `YYYYMMDD`) to the list above. This ensures newly generated
@@ -48,3 +49,4 @@ branch naming or stacking are enforced here.
 - f35652058bed6794dd00d6432f2ae81a6980ff07
 - ea1a04aef0e11407db1d94d0f1692ea0bfa2848b
 - bea7eeef689a3ac7863217007d71fc0fb4a230c4
+- f7d1ab65a996dd1072d53d3d6422b0daadc1c035

--- a/prompts/07/29/20250729T145215-0400.md
+++ b/prompts/07/29/20250729T145215-0400.md
@@ -70,6 +70,8 @@ This table lists the essential components produced by the OBK scaffold process. 
 
 <gsl-test id="T1">TBD</gsl-test>
 
+<gsl-test id="T2">`obk divide 4 2` logs "Divide 4 by 2 = 2.0"</gsl-test>
+
 
 </gsl-tdd>
 

--- a/src/obk/cli.py
+++ b/src/obk/cli.py
@@ -3,10 +3,26 @@
 from __future__ import annotations
 
 import argparse
+import logging
+from pathlib import Path
+
+LOG_FILE = Path("obk.log")
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    handlers=[logging.FileHandler(LOG_FILE, encoding="utf-8")],
+)
 
 
 def _cmd_hello_world(_: argparse.Namespace) -> None:
     print("hello world")
+
+
+def _cmd_divide(args: argparse.Namespace) -> None:
+    """Divide two numbers and log the operation."""
+    result = args.a / args.b
+    logging.getLogger(__name__).info("Divide %s by %s = %s", args.a, args.b, result)
+    print(result)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -17,6 +33,15 @@ def build_parser() -> argparse.ArgumentParser:
         "hello-world", help="Print hello world", description="Print hello world"
     )
     hello_parser.set_defaults(func=_cmd_hello_world)
+
+    divide_parser = subparsers.add_parser(
+        "divide",
+        help="Divide two numbers",
+        description="Divide a by b",
+    )
+    divide_parser.add_argument("a", type=float, help="Dividend")
+    divide_parser.add_argument("b", type=float, help="Divisor")
+    divide_parser.set_defaults(func=_cmd_divide)
     return parser
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,3 +44,20 @@ def test_entrypoint_any_directory(tmp_path):
         env=env,
     )
     assert result.stdout.strip() == "hello world"
+
+
+def test_divide_logs(tmp_path):
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    result = subprocess.run(
+        [sys.executable, "-m", "obk", "divide", "4", "2"],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    assert result.stdout.strip() == "2.0"
+    log_file = tmp_path / "obk.log"
+    assert log_file.exists()
+    assert "Divide 4.0 by 2.0 = 2.0" in log_file.read_text()


### PR DESCRIPTION
## Summary
- implement `divide` subcommand in the CLI
- write INFO log entries for division results
- test that the log file records division
- document the new test case
- track the commit in `AGENTS.md`

## Testing
- `ruff check src/obk/cli.py tests/test_cli.py`
- `black src/obk/cli.py tests/test_cli.py`
- `pytest -q`
- `python scripts/get_prompt_id.py -t UTC`

------
https://chatgpt.com/codex/tasks/task_e_6889348da45483239273a8b34ccb3a03