### PR TITLE
Add run_cli divide logging test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,3 +50,4 @@ branch naming or stacking are enforced here.
 - ea1a04aef0e11407db1d94d0f1692ea0bfa2848b
 - bea7eeef689a3ac7863217007d71fc0fb4a230c4
 - f7d1ab65a996dd1072d53d3d6422b0daadc1c035
+- ee4c5b69ff16ad80b9cf1995b26a20cb5a76b258

--- a/prompts/07/29/20250729T145215-0400.md
+++ b/prompts/07/29/20250729T145215-0400.md
@@ -72,6 +72,8 @@ This table lists the essential components produced by the OBK scaffold process. 
 
 <gsl-test id="T2">`obk divide 4 2` logs "Divide 4 by 2 = 2.0"</gsl-test>
 
+<gsl-test id="T3">`run_cli([\"divide\", \"4\", \"2\"])` logs "Divide 4.0 by 2.0 = 2.0"</gsl-test>
+
 
 </gsl-tdd>
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,20 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 
+def run_cli(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    """Run the obk CLI with the given arguments."""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    return subprocess.run(
+        [sys.executable, "-m", "obk", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=cwd,
+        env=env,
+    )
+
+
 def test_hello_world():
     env = os.environ.copy()
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
@@ -61,3 +75,11 @@ def test_divide_logs(tmp_path):
     log_file = tmp_path / "obk.log"
     assert log_file.exists()
     assert "Divide 4.0 by 2.0 = 2.0" in log_file.read_text()
+
+
+def test_run_cli_divide(tmp_path):
+    result = run_cli(["divide", "4", "2"], cwd=tmp_path)
+    assert result.stdout.strip() == "2.0"
+    log_file = tmp_path / "obk.log"
+    assert log_file.exists()
+    assert "INFO [obk.cli] Divide 4.0 by 2.0 = 2.0" in log_file.read_text()


### PR DESCRIPTION
## Summary
- add helper `run_cli` to CLI tests
- test divide command logging using run_cli
- document new test case in the July 29 prompt
- record latest commit in AGENTS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688938dca02c83238f6aaa5696539393