### PR TITLE
Add Typer CLI features

### DIFF
--- a/prompts/07/30/20250730T160316-0400.md
+++ b/prompts/07/30/20250730T160316-0400.md
@@ -129,6 +129,11 @@ You may add a code block (with triple backticks) under each test if needed.
 
 </gsl-test>
 
+<gsl-test id="T6"> obk greet Ada -> Hello, Ada.</gsl-test>
+<gsl-test id="T7"> obk greet Ada --excited -> Hello, Ada!!!</gsl-test>
+<gsl-test id="T8"> obk divide 4 2 -> 2.0</gsl-test>
+<gsl-test id="T9"> obk divide 1 0 -> exit 2</gsl-test>
+<gsl-test id="T10"> obk hello-world -h -> shows 'Print hello world'</gsl-test>
 </gsl-tdd>
 
 <gsl-document-spec>
@@ -174,4 +179,3 @@ These rules protect the integrity of the document and its tests, while allowing 
 
 </gsl-document-spec>
 </gsl-block>
-</gsl-prompt>

--- a/src/obk/cli.py
+++ b/src/obk/cli.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-import argparse
+from __future__ import annotations
+
 import logging
 import sys
 from pathlib import Path
+
+import typer
 
 from .containers import Container
 from .services import DivisionByZeroError, FatalError
@@ -40,72 +43,73 @@ sys.excepthook = _global_excepthook
 
 
 class ObkCLI:
-    """Class-based CLI implementation using dependency injection."""
+    """Typer-based CLI with dependency injection."""
 
     def __init__(self, log_file: Path = LOG_FILE, container: Container | None = None) -> None:
         self.container = container or Container()
-        self.container.config.log_file.from_value(log_file)
         self.log_file = log_file
 
-    # command implementations -------------------------------------------------
-    def _cmd_hello_world(self, _: argparse.Namespace) -> None:
-        greeter = self.container.greeter()
-        print(greeter.hello())
-
-    def _cmd_divide(self, args: argparse.Namespace) -> None:
-        divider = self.container.divider()
-        result = divider.divide(args.a, args.b)
-        logging.getLogger(__name__).info(
-            "Divide %s by %s = %s", args.a, args.b, result
+        self.app = typer.Typer(
+            add_completion=False,
+            context_settings={"help_option_names": ["-h", "--help"]},
         )
-        print(result)
 
-    def _cmd_fail(self, _: argparse.Namespace) -> None:
+        self.app.callback()(self._callback)
+        self.app.command(
+            name="hello-world",
+            help="Print hello world",
+            short_help="Print hello world",
+        )(self._cmd_hello_world)
+        self.app.command(
+            name="divide",
+            help="Divide a by b",
+            short_help="Divide two numbers",
+        )(self._cmd_divide)
+        self.app.command(
+            name="fail",
+            help="Trigger a fatal error",
+            short_help="Trigger a fatal error",
+        )(self._cmd_fail)
+        self.app.command(
+            name="greet",
+            help="Greet by name with optional excitement",
+            short_help="Greet by name",
+        )(self._cmd_greet)
+
+    # callback ---------------------------------------------------------------
+    def _callback(self, logfile: Path = typer.Option(LOG_FILE, help="Path to the log file")) -> None:
+        self.container.config.log_file.from_value(logfile)
+        configure_logging(self.container.config.log_file())
+
+    # command implementations -------------------------------------------------
+    def _cmd_hello_world(self) -> None:
+        greeter = self.container.greeter()
+        typer.echo(greeter.hello())
+
+    def _cmd_divide(self, a: float, b: float) -> None:
+        divider = self.container.divider()
+        result = divider.divide(a, b)
+        logging.getLogger(__name__).info("Divide %s by %s = %s", a, b, result)
+        typer.echo(result)
+
+    def _cmd_fail(self) -> None:
         raise FatalError("intentional failure")
 
-    # parser / runner ---------------------------------------------------------
-    def build_parser(self) -> argparse.ArgumentParser:
-        parser = argparse.ArgumentParser(prog="obk")
-        parser.add_argument(
-            "--logfile",
-            type=Path,
-            default=self.log_file,
-            help="Path to the log file",
-        )
-        subparsers = parser.add_subparsers(dest="command", required=True)
+    def _cmd_greet(self, name: str, excited: bool = False) -> None:
+        if excited:
+            typer.echo(f"Hello, {name}!!!")
+        else:
+            typer.echo(f"Hello, {name}.")
 
-        hello_parser = subparsers.add_parser(
-            "hello-world", help="Print hello world", description="Print hello world"
-        )
-        hello_parser.set_defaults(func=self._cmd_hello_world)
-
-        divide_parser = subparsers.add_parser(
-            "divide",
-            help="Divide two numbers",
-            description="Divide a by b",
-        )
-        divide_parser.add_argument("a", type=float, help="Dividend")
-        divide_parser.add_argument("b", type=float, help="Divisor")
-        divide_parser.set_defaults(func=self._cmd_divide)
-
-        fail_parser = subparsers.add_parser(
-            "fail",
-            help="Trigger a fatal error",
-            description="Trigger a fatal error",
-        )
-        fail_parser.set_defaults(func=self._cmd_fail)
-        return parser
-
+    # runner ---------------------------------------------------------------
     def run(self, argv: list[str] | None = None) -> None:
-        parser = self.build_parser()
-        args = parser.parse_args(argv)
-        self.container.config.log_file.from_value(args.logfile)
-        configure_logging(self.container.config.log_file())
+        argv = argv or sys.argv[1:]
         try:
-            args.func(args)
+            cmd = typer.main.get_command(self.app)
+            cmd.main(args=argv, prog_name="obk", standalone_mode=False)
         except DivisionByZeroError as exc:
             logging.getLogger(__name__).exception("Division error")
-            print(f"[ERROR] {exc}", file=sys.stderr)
+            typer.echo(f"[ERROR] {exc}", err=True)
             sys.exit(2)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -151,3 +151,16 @@ def test_container_override_divider(tmp_path, capsys):
     cli.run(["divide", "1", "3"])
     captured = capsys.readouterr()
     assert captured.out.strip() == "42"
+
+def test_greet_excited(tmp_path):
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    result = subprocess.run(
+        [sys.executable, "-m", "obk", "greet", "Ada", "--excited"],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    assert result.stdout.strip() == "Hello, Ada!!!"


### PR DESCRIPTION
## Summary
- convert CLI to use Typer
- keep existing commands and add `greet` command with `--excited`
- update tests for new CLI
- document manual tests in prompt file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a816831508323a512bc33816b0646