### PR TITLE
Add prompt validation, harmonization, and trace ID

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include LICENSE
+recursive-include src/obk/xsd *.xsd

--- a/prompts/07/31/20250731T185109-0400.md
+++ b/prompts/07/31/20250731T185109-0400.md
@@ -63,6 +63,16 @@ Implement prompt file validation, harmonization, and trace ID generation as OBK 
 - T5: The validation, harmonization, and trace-id commands use only OBK-branded output and help text; no reference to the guide or any external tool
 </gsl-test>
 
+<gsl-test id="T6">
+
+- T6: Running `obk validate-all` on valid prompts prints "All prompt files are valid."
+</gsl-test>
+
+<gsl-test id="T7">
+
+- T7: `obk harmonize-all` removes indentation on XML lines
+</gsl-test>
+
 </gsl-tdd>
 
 <gsl-document-spec>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.9"
 dependencies = [
     "typer>=0.12",
     "dependency-injector>=4.41",
+    "lxml>=5.2",
 ]
 
 [project.scripts]
@@ -20,6 +21,7 @@ obk = "obk.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/obk"]
+include = ["src/obk/xsd/*.xsd"]
 
 [tool.hatch.envs.default]
 dependencies = [

--- a/src/obk/cli.py
+++ b/src/obk/cli.py
@@ -12,6 +12,10 @@ import typer
 
 from .containers import Container
 from .services import DivisionByZeroError, FatalError
+from .trace_id import generate_trace_id
+from .validation import validate_all
+from .preprocess import preprocess_text, postprocess_text
+from .harmonize import harmonize_text
 
 
 LOG_FILE = Path("obk.log")
@@ -81,6 +85,21 @@ class ObkCLI:
             help="Greet by name with optional excitement",
             short_help="Greet by name",
         )(self._cmd_greet)
+        self.app.command(
+            name="validate-all",
+            help="Validate all prompt files",
+            short_help="Validate prompts",
+        )(self._cmd_validate_all)
+        self.app.command(
+            name="harmonize-all",
+            help="Harmonize all prompt files",
+            short_help="Harmonize prompts",
+        )(self._cmd_harmonize_all)
+        self.app.command(
+            name="trace-id",
+            help="Generate a trace ID",
+            short_help="Generate trace ID",
+        )(self._cmd_trace_id)
 
     # callback ---------------------------------------------------------------
     def _callback(
@@ -107,12 +126,44 @@ class ObkCLI:
         greeter = self.container.greeter()
         typer.echo(greeter.greet(name, excited))
 
+    def _cmd_validate_all(
+        self,
+        prompts_dir: Path = Path("prompts"),
+        schema_path: Path = Path(__file__).resolve().parent / "xsd" / "prompt.xsd",
+    ) -> None:
+        errors = validate_all(prompts_dir, schema_path)
+        if errors:
+            for err in errors:
+                typer.echo(err, err=True)
+            raise typer.Exit(code=1)
+        typer.echo("All prompt files are valid.")
+
+    def _cmd_harmonize_all(
+        self,
+        prompts_dir: Path = Path("prompts"),
+        dry_run: bool = typer.Option(False, help="Show changes without saving"),
+    ) -> None:
+        for file_path in prompts_dir.rglob("*.md"):
+            original = file_path.read_text(encoding="utf-8")
+            processed, placeholders = preprocess_text(original)
+            harmonized, actions = harmonize_text(processed)
+            final = postprocess_text(harmonized, placeholders)
+            if not dry_run:
+                file_path.write_text(final, encoding="utf-8")
+            for act in actions:
+                typer.echo(f"✔️ {act} in {file_path.name}")
+
+    def _cmd_trace_id(self, timezone: str = "UTC") -> None:
+        typer.echo(generate_trace_id(timezone))
+
     # runner ---------------------------------------------------------------
     def run(self, argv: list[str] | None = None) -> None:
         argv = argv or sys.argv[1:]
         try:
             cmd = typer.main.get_command(self.app)
-            cmd.main(args=argv, prog_name="obk", standalone_mode=False)
+            exit_code = cmd.main(args=argv, prog_name="obk", standalone_mode=False)
+            if isinstance(exit_code, int):
+                sys.exit(exit_code)
         except DivisionByZeroError as exc:
             logging.getLogger(__name__).exception("Division error")
             typer.echo(f"[ERROR] {exc}", err=True)

--- a/src/obk/harmonize.py
+++ b/src/obk/harmonize.py
@@ -1,0 +1,26 @@
+from typing import List, Tuple
+
+
+def harmonize_text(text: str) -> Tuple[str, List[str]]:
+    lines = text.splitlines()
+    actions: List[str] = []
+    i = 0
+    in_code = False
+    while i < len(lines):
+        line = lines[i]
+        if line.lstrip().startswith("```") or line.lstrip().startswith("~~~"):
+            in_code = not in_code
+            i += 1
+            continue
+        if in_code:
+            i += 1
+            continue
+        stripped = line.lstrip()
+        if stripped.startswith("<") and line != stripped:
+            lines[i] = stripped
+            actions.append(f"Removed indentation for XML element on line {i + 1}")
+        i += 1
+    result = "\n".join(lines)
+    if text.endswith("\n"):
+        result += "\n"
+    return result, actions

--- a/src/obk/preprocess.py
+++ b/src/obk/preprocess.py
@@ -1,0 +1,31 @@
+import html
+import re
+from typing import List, Tuple
+
+_CODE_PATTERN = re.compile(r"(?:```.*?```|~~~.*?~~~|`[^`]*`)", re.S)
+
+
+def preprocess_text(text: str) -> Tuple[str, List[str]]:
+    """Return XML-safe text and a list of placeholders."""
+    placeholders: List[str] = []
+
+    def _code_repl(match: re.Match[str]) -> str:
+        placeholders.append(match.group(0))
+        return f"__GSL_CODE_{len(placeholders) - 1}__"
+
+    text = _CODE_PATTERN.sub(_code_repl, text)
+
+    parts = re.split(r"(<[/?A-Za-z][^>]*>)", text)
+    for i, part in enumerate(parts):
+        if part.startswith("<") and part.endswith(">"):
+            continue
+        parts[i] = html.escape(part, quote=True)
+    processed = "".join(parts)
+    return processed, placeholders
+
+
+def postprocess_text(text: str, placeholders: List[str]) -> str:
+    """Replace placeholders with original code and unescape XML entities."""
+    for idx, original in enumerate(placeholders):
+        text = text.replace(f"__GSL_CODE_{idx}__", original)
+    return html.unescape(text)

--- a/src/obk/trace_id.py
+++ b/src/obk/trace_id.py
@@ -1,0 +1,8 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+
+def generate_trace_id(tz_name: str = "UTC") -> str:
+    tz = ZoneInfo(tz_name)
+    now = datetime.now(ZoneInfo("UTC")).astimezone(tz)
+    return now.strftime("%Y%m%dT%H%M%S%z")

--- a/src/obk/validation.py
+++ b/src/obk/validation.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+from typing import List
+
+from lxml import etree
+
+from .preprocess import preprocess_text
+
+
+def validate_all(prompts_dir: Path, schema_path: Path) -> List[str]:
+    schema_doc = etree.parse(str(schema_path))
+    schema = etree.XMLSchema(schema_doc)
+    errors: List[str] = []
+    for file_path in prompts_dir.rglob("*.md"):
+        text = file_path.read_text(encoding="utf-8")
+        processed, _ = preprocess_text(text)
+        try:
+            tree = etree.fromstring(processed.encode("utf-8"))
+            schema.assertValid(tree)
+        except Exception as exc:
+            errors.append(f"{file_path}: {exc}")
+    return errors


### PR DESCRIPTION
## Summary
- implement text preprocessing and harmonization helpers
- add XML validation utilities
- add trace-id generator
- expose `validate-all`, `harmonize-all`, and `trace-id` commands
- include XSD in build and update prompt tests
- cover new behaviour in CLI tests

## Testing
- `ruff check src tests`
- `black src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bf8d83478832395cb824ae84e61a3