### PR TITLE
Fix CLI prompts exit behavior and tests

### DIFF
--- a/src/obk/cli.py
+++ b/src/obk/cli.py
@@ -21,7 +21,14 @@ LOG_FILE = Path("obk.log")
 
 def get_default_prompts_dir():
     today = datetime.now()
-    return REPO_ROOT / "prompts" / f"{today.year:04}" / f"{today.month:02}" / f"{today.day:02}"
+    return (
+        REPO_ROOT
+        / "prompts"
+        / f"{today.year:04}"
+        / f"{today.month:02}"
+        / f"{today.day:02}"
+    )
+
 
 def find_prompts_root() -> Path:
     """Search upwards from CWD for the 'prompts' directory."""
@@ -34,6 +41,7 @@ def find_prompts_root() -> Path:
         "Could not find 'prompts' directory. Please run this command from within your project tree."
     )
 
+
 def configure_logging(log_file: Path) -> None:
     """Configure root logging to write to ``log_file``."""
     logging.basicConfig(
@@ -41,6 +49,7 @@ def configure_logging(log_file: Path) -> None:
         format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
         handlers=[logging.FileHandler(log_file, encoding="utf-8")],
     )
+
 
 def _global_excepthook(
     exc_type: type[BaseException], exc_value: BaseException, exc_tb
@@ -57,7 +66,9 @@ def _global_excepthook(
     )
     sys.exit(1)
 
+
 sys.excepthook = _global_excepthook
+
 
 class ObkCLI:
     """Typer-based CLI with dependency injection."""
@@ -154,11 +165,16 @@ class ObkCLI:
             typer.echo(f"❌ Validation errors found in {failed} file(s):")
             for err in errors:
                 typer.echo(f"  - {err}", err=True)
+        elif passed == 0:
+            typer.echo("No prompt files found.")
         else:
-            typer.echo(f"✅ All {passed} prompt files for today validated successfully!")
+            typer.echo(
+                f"✅ All {passed} prompt files for today validated successfully!"
+            )
         typer.echo(f"\nSummary: {passed} passed, {failed} failed.\n")
         if failed > 0:
             raise typer.Exit(code=1)
+        raise typer.Exit(code=0)
 
     def _cmd_validate_all(
         self,
@@ -172,7 +188,11 @@ class ObkCLI:
         ),
     ) -> None:
         if prompts_dir is None:
-            prompts_dir = find_prompts_root()
+            try:
+                prompts_dir = find_prompts_root()
+            except FileNotFoundError as e:
+                typer.echo(f"❌ {e}", err=True)
+                raise typer.Exit(code=2)
         else:
             prompts_dir = Path(prompts_dir)
         typer.echo(f"Validating ALL prompts under: {prompts_dir.resolve()}")
@@ -181,11 +201,14 @@ class ObkCLI:
             typer.echo(f"❌ Validation errors found in {failed} file(s):")
             for err in errors:
                 typer.echo(f"  - {err}", err=True)
+        elif passed == 0:
+            typer.echo("No prompt files found.")
         else:
             typer.echo("All prompt files are valid")
         typer.echo(f"\nSummary: {passed} passed, {failed} failed.\n")
         if failed > 0:
             raise typer.Exit(code=1)
+        raise typer.Exit(code=0)
 
     def _cmd_harmonize_today(
         self,
@@ -193,15 +216,32 @@ class ObkCLI:
     ) -> None:
         prompts_dir = get_default_prompts_dir()
         typer.echo(f"Harmonizing TODAY's prompts under: {prompts_dir.resolve()}")
+        total_files = 0
+        changed_files = 0
         for file_path in prompts_dir.rglob("*.md"):
+            total_files += 1
             original = file_path.read_text(encoding="utf-8")
             processed, placeholders = preprocess_text(original)
             harmonized, actions = harmonize_text(processed)
             final = postprocess_text(harmonized, placeholders)
-            if not dry_run:
+            if final != original:
+                changed_files += 1
+            if not dry_run and final != original:
                 file_path.write_text(final, encoding="utf-8")
-            for act in actions:
-                typer.echo(f"✔️ {act} in {file_path.name}")
+            if actions:
+                for act in actions:
+                    prefix = "Would " if dry_run else ""
+                    typer.echo(f"✔️ {prefix}{act} in {file_path.name}")
+
+        if total_files == 0:
+            typer.echo("No prompt files found.")
+        typer.echo(
+            f"\nSummary: {changed_files if not dry_run else 0} file(s)"
+            f"{' would be' if dry_run else ''} harmonized out of {total_files} checked.\n"
+        )
+        if dry_run:
+            typer.echo("Dry run: No files were modified.\n")
+        raise typer.Exit(code=0)
 
     def _cmd_harmonize_all(
         self,
@@ -228,17 +268,24 @@ class ObkCLI:
             processed, placeholders = preprocess_text(original)
             harmonized, actions = harmonize_text(processed)
             final = postprocess_text(harmonized, placeholders)
+            if final != original:
+                changed_files += 1
             if not dry_run and final != original:
                 file_path.write_text(final, encoding="utf-8")
-                changed_files += 1
             if actions:
                 for act in actions:
-                    typer.echo(f"✔️ {act} in {file_path.name}")
+                    prefix = "Would " if dry_run else ""
+                    typer.echo(f"✔️ {prefix}{act} in {file_path.name}")
 
-        typer.echo(f"\nSummary: {changed_files} file(s) harmonized out of {total_files} checked.\n")
+        if total_files == 0:
+            typer.echo("No prompt files found.")
+        typer.echo(
+            f"\nSummary: {changed_files if not dry_run else 0} file(s)"
+            f"{' would be' if dry_run else ''} harmonized out of {total_files} checked.\n"
+        )
         if dry_run:
             typer.echo("Dry run: No files were modified.\n")
-
+        raise typer.Exit(code=0)
 
     def _cmd_trace_id(self, timezone: str = "UTC") -> None:
         typer.echo(generate_trace_id(timezone))
@@ -254,6 +301,7 @@ class ObkCLI:
             logging.getLogger(__name__).exception("Division error")
             typer.echo(f"[ERROR] {exc}", err=True)
             sys.exit(2)
+
 
 def main(argv: list[str] | None = None) -> None:
     """Entry point for ``python -m obk``."""

--- a/src/obk/harmonize.py
+++ b/src/obk/harmonize.py
@@ -1,12 +1,15 @@
 import re
 from typing import List, Tuple
 
+
 def harmonize_text(text: str) -> Tuple[str, List[str]]:
     lines = text.splitlines()
     out_lines = []
     in_code_block = False
     actions = []
-    opening_tag_regex = re.compile(r"<[a-zA-Z0-9_\-]+(\s+[^>]*)?>\s*$")  # matches <tag> or <tag attr="...">
+    opening_tag_regex = re.compile(
+        r"<[a-zA-Z0-9_\-]+(\s+[^>]*)?>\s*$"
+    )  # matches <tag> or <tag attr="...">
     i = 0
     while i < len(lines):
         line = lines[i]
@@ -19,7 +22,7 @@ def harmonize_text(text: str) -> Tuple[str, List[str]]:
         if in_code_block:
             i += 1
             continue
-        
+
         # check for trailing text on same line after opening tag
         match = re.match(r"^(.*(<[a-zA-Z0-9_\-]+(\s+[^>]*)?>))([^\n<]+.*)$", line)
         if match:
@@ -30,7 +33,7 @@ def harmonize_text(text: str) -> Tuple[str, List[str]]:
             actions.append(f"Split and inserted blank after opening tag at line {i+1}")
             i += 1
             continue
-        
+
         # if line ends with an opening tag, check next line for blank
         if opening_tag_regex.search(line):
             if i + 1 < len(lines):
@@ -41,5 +44,5 @@ def harmonize_text(text: str) -> Tuple[str, List[str]]:
                     actions.append(f"Inserted blank after opening tag at line {i+1}")
         i += 1
 
-    result_text = "\n".join(out_lines) + ("\n" if text.endswith('\n') else "")
+    result_text = "\n".join(out_lines) + ("\n" if text.endswith("\n") else "")
     return result_text, actions

--- a/src/obk/validation.py
+++ b/src/obk/validation.py
@@ -3,6 +3,7 @@ from typing import List, Tuple
 from lxml import etree
 from .preprocess import preprocess_text
 
+
 def validate_all(prompts_dir: Path, schema_path: Path) -> Tuple[List[str], int, int]:
     """
     Validates all prompt files under prompts_dir using the given XSD schema.
@@ -10,13 +11,13 @@ def validate_all(prompts_dir: Path, schema_path: Path) -> Tuple[List[str], int, 
     """
     schema_doc = etree.parse(str(schema_path.resolve()))
     schema = etree.XMLSchema(schema_doc)
-    
+
     errors: List[str] = []
     count_passed = 0
     count_failed = 0
-    
+
     prompts_dir = prompts_dir.resolve()  # absolute path
-    
+
     for file_path in prompts_dir.rglob("*.md"):
         text = file_path.read_text(encoding="utf-8")
         processed, _ = preprocess_text(text)
@@ -27,5 +28,5 @@ def validate_all(prompts_dir: Path, schema_path: Path) -> Tuple[List[str], int, 
         except Exception as exc:
             errors.append(f"{file_path}: {exc}")
             count_failed += 1
-    
+
     return errors, count_passed, count_failed

--- a/tests/test_prompt_features.py
+++ b/tests/test_prompt_features.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import obk.cli as cli
 
 PYTHON = sys.executable
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -54,23 +55,24 @@ def test_validate_all(tmp_path):
 def test_harmonize_all_and_dry_run(tmp_path):
     prompts = tmp_path / "prompts"
     prompt = prompts / "harm.md"
-    _write_prompt(
-        prompt,
-        "<gsl-prompt id='20250731T000000+0000'>\n    <gsl-header>h</gsl-header>\n<gsl-block>\n    <gsl-purpose>p</gsl-purpose>\n</gsl-block>\n</gsl-prompt>\n",
+    content = (
+        "<gsl-prompt id='20250731T000000+0000'>\n    <gsl-header>h</gsl-header>\n"
+        "<gsl-block>\n    <gsl-purpose>p</gsl-purpose>\n</gsl-block>\n</gsl-prompt>\n"
     )
+    _write_prompt(prompt, content)
 
     result = _run(["harmonize-all", "--prompts-dir", str(prompts)], cwd=tmp_path)
     assert result.returncode == 0
     txt = prompt.read_text()
     assert txt.splitlines()[1].startswith("<gsl-header>")
 
-    original = txt
+    _write_prompt(prompt, content)  # reset to original
     result = _run(
         ["harmonize-all", "--prompts-dir", str(prompts), "--dry-run"], cwd=tmp_path
     )
     assert result.returncode == 0
     assert "Would" in result.stdout
-    assert original == prompt.read_text()
+    assert content == prompt.read_text()
 
 
 # T3
@@ -104,7 +106,6 @@ def test_trace_id_timezones(tmp_path):
 
 
 # Helpers for T5/T6
-import obk.cli as cli
 
 
 def _patch_repo_root(tmp_path, monkeypatch):
@@ -145,10 +146,11 @@ def test_harmonize_today(monkeypatch, capsys, tmp_path):
     prompts_dir = _patch_repo_root(tmp_path, monkeypatch)
     prompts_dir.mkdir(parents=True)
     file = prompts_dir / "harm.md"
-    _write_prompt(
-        file,
-        "<gsl-prompt id='20250731T000000+0000'>\n    <gsl-header>h</gsl-header>\n<gsl-block>\n    <gsl-purpose>p</gsl-purpose>\n</gsl-block>\n</gsl-prompt>\n",
+    content = (
+        "<gsl-prompt id='20250731T000000+0000'>\n    <gsl-header>h</gsl-header>\n"
+        "<gsl-block>\n    <gsl-purpose>p</gsl-purpose>\n</gsl-block>\n</gsl-prompt>\n"
     )
+    _write_prompt(file, content)
 
     cli_obj = cli.ObkCLI()
     with pytest.raises(SystemExit) as exc:
@@ -158,8 +160,7 @@ def test_harmonize_today(monkeypatch, capsys, tmp_path):
     assert "1 file" in captured.out
     assert "Summary" in captured.out
 
-    txt = file.read_text()
-    _write_prompt(file, txt)  # reset
+    _write_prompt(file, content)  # reset to original
     with pytest.raises(SystemExit) as exc:
         cli_obj.run(["harmonize-today", "--dry-run"])
     captured = capsys.readouterr()


### PR DESCRIPTION
## Summary
- implement exit codes and summaries for prompt commands
- add dry-run messaging for harmonize commands
- fix tests to reset prompt data before dry-run

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c3d4333ec8323917b8b911f11d20c