### PR TITLE
Improve CLI exception output

### DIFF
--- a/src/obk/cli.py
+++ b/src/obk/cli.py
@@ -62,7 +62,8 @@ def _global_excepthook(
         "Uncaught exception", exc_info=(exc_type, exc_value, exc_tb)
     )
     print(
-        "[FATAL] Unexpected error occurred. See the log for details.", file=sys.stderr
+        f"[FATAL] {exc_type.__name__}: {exc_value}\nSee the log for details.",
+        file=sys.stderr,
     )
     sys.exit(1)
 


### PR DESCRIPTION
## Summary
- print exception details for fatal errors to assist debugging

## Testing
- `ruff check --fix`
- `black --check --diff src/obk/cli.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c42cf79248323859f4f6e70bc4ba4