### PR TITLE
Implement xmlschema-based prompt validation

### DIFF
--- a/prompts/2025/08/01/20250801T153742+0000.md
+++ b/prompts/2025/08/01/20250801T153742+0000.md
@@ -76,6 +76,26 @@ You may add a code block (with triple backticks) under each test if needed.
 - [TO FILL: Short test description]
 </gsl-test>
 
+<gsl-test id="T2">
+
+- T2: `obk validate-all --prompts-dir valid_prompts/` -> All prompt files are valid
+</gsl-test>
+
+<gsl-test id="T3">
+
+- T3: `obk validate-all --prompts-dir invalid_prompts/` -> reports validation error
+</gsl-test>
+
+<gsl-test id="T4">
+
+- T4: file name containing "surgery" uses mapped schema during validation
+</gsl-test>
+
+<gsl-test id="T5">
+
+- T5: schemas load via `importlib.resources` when installed as a package
+</gsl-test>
+
 </gsl-tdd>
 
 <gsl-document-spec>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ requires-python = ">=3.9"
 dependencies = [
     "typer>=0.12",
     "dependency-injector>=4.41",
-    "lxml>=5.2",
-	"tzdata>=2024.1",
+    "xmlschema>=3.2",
+    "tzdata>=2024.1",
 ]
 
 [project.scripts]

--- a/src/obk/cli.py
+++ b/src/obk/cli.py
@@ -155,13 +155,10 @@ class ObkCLI:
         greeter = self.container.greeter()
         typer.echo(greeter.greet(name, excited))
 
-    def _cmd_validate_today(
-        self,
-        schema_path: Path = Path(__file__).resolve().parent / "xsd" / "prompt.xsd",
-    ) -> None:
+    def _cmd_validate_today(self) -> None:
         prompts_dir = get_default_prompts_dir()
         typer.echo(f"Validating today's prompts under: {prompts_dir.resolve()}")
-        errors, passed, failed = validate_all(prompts_dir, schema_path)
+        errors, passed, failed = validate_all(prompts_dir)
         if errors:
             typer.echo(f"[ERROR] Validation errors found in {failed} file(s):")
             for err in errors:
@@ -182,11 +179,6 @@ class ObkCLI:
         prompts_dir: Path | None = typer.Option(
             None, help="Path to the prompts directory"
         ),
-        schema_path: Path = typer.Option(
-            Path(__file__).resolve().parent / "xsd" / "prompt.xsd",
-            "--schema",
-            help="Path to the GSL prompt schema",
-        ),
     ) -> None:
         if prompts_dir is None:
             try:
@@ -197,7 +189,7 @@ class ObkCLI:
         else:
             prompts_dir = Path(prompts_dir)
         typer.echo(f"Validating ALL prompts under: {prompts_dir.resolve()}")
-        errors, passed, failed = validate_all(prompts_dir, schema_path)
+        errors, passed, failed = validate_all(prompts_dir)
         if errors:
             typer.echo(f"[ERROR] Validation errors found in {failed} file(s):")
             for err in errors:

--- a/src/obk/validation.py
+++ b/src/obk/validation.py
@@ -1,32 +1,55 @@
+from importlib.resources import files
 from pathlib import Path
 from typing import List, Tuple
-from lxml import etree
+
+import xmlschema
+
 from .preprocess import preprocess_text
 
+PROMPT_SCHEMA_MAP = {
+    "gsl": "prompt.xsd",
+    "surgery": "prompt.xsd",
+}
 
-def validate_all(prompts_dir: Path, schema_path: Path) -> Tuple[List[str], int, int]:
-    """
-    Validates all prompt files under prompts_dir using the given XSD schema.
-    Returns a tuple: (list of error messages, count_passed, count_failed)
-    """
-    schema_doc = etree.parse(str(schema_path.resolve()))
-    schema = etree.XMLSchema(schema_doc)
+
+def get_schema_path(schema_name: str) -> Path:
+    return files("obk.xsd").joinpath(schema_name)
+
+
+def detect_prompt_type(file_path: Path) -> str:
+    name = file_path.stem.lower()
+    if "surgery" in name:
+        return "surgery"
+    return "gsl"
+
+
+def validate_all(prompts_dir: Path) -> Tuple[List[str], int, int]:
+    """Validate all prompts under ``prompts_dir`` using mapped schemas."""
 
     errors: List[str] = []
     count_passed = 0
     count_failed = 0
 
-    prompts_dir = prompts_dir.resolve()  # absolute path
+    prompts_dir = prompts_dir.resolve()
 
     for file_path in prompts_dir.rglob("*.md"):
         text = file_path.read_text(encoding="utf-8")
         processed, _ = preprocess_text(text)
+        prompt_type = detect_prompt_type(file_path)
+        schema_name = PROMPT_SCHEMA_MAP.get(prompt_type, "prompt.xsd")
+        schema_path = get_schema_path(schema_name)
+        schema = xmlschema.XMLSchema(str(schema_path))
         try:
-            tree = etree.fromstring(processed.encode("utf-8"))
-            schema.assertValid(tree)
-            count_passed += 1
-        except Exception as exc:
-            errors.append(f"{file_path}: {exc}")
+            file_errors = [
+                err.reason or str(err) for err in schema.iter_errors(processed)
+            ]
+        except xmlschema.XMLSchemaException as exc:
+            file_errors = [str(exc)]
+        if file_errors:
+            for msg in file_errors:
+                errors.append(f"{file_path}: {msg}")
             count_failed += 1
+        else:
+            count_passed += 1
 
     return errors, count_passed, count_failed

--- a/tests/test_prompt_features.py
+++ b/tests/test_prompt_features.py
@@ -193,12 +193,17 @@ def test_autolocate_prompts_from_subdir(tmp_path):
 
 
 # T9
-def test_summary_no_prompts(tmp_path):
-    prompts = tmp_path / "prompts"
-    prompts.mkdir()
-    res = _run(["harmonize-today"], cwd=tmp_path)
-    assert "No prompt files found" in res.stdout
-    assert "Summary" in res.stdout
+def test_summary_no_prompts(monkeypatch, capsys, tmp_path):
+    prompts_dir = _patch_repo_root(tmp_path, monkeypatch)
+    prompts_dir.mkdir(parents=True)
+
+    cli_obj = cli.ObkCLI()
+    with pytest.raises(SystemExit) as exc:
+        cli_obj.run(["harmonize-today"])
+    captured = capsys.readouterr()
+    assert exc.value.code == 0
+    assert "No prompt files found" in captured.out
+    assert "Summary" in captured.out
 
 
 # T10


### PR DESCRIPTION
## Summary
- switch validation to `xmlschema` and add schema registry
- load schemas using `importlib.resources`
- remove `--schema` option from validate commands
- add manual tests describing multi-XSD behaviour
- update tests for new validation logic

## Testing
- `ruff check .`
- `black --check src tests scripts`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d2f1a9dc48323be466c23f0f15b4f