### PR TITLE
feat: synchronize today folder by timezone

### DIFF
--- a/prompts/2025/08/01/20250802T024329+0000.md
+++ b/prompts/2025/08/01/20250802T024329+0000.md
@@ -89,6 +89,21 @@ Add single-line manual tests (see `one-line-manual-tests.md`). Each `<gsl-test>`
 - T3: <!-- [placeholder] Edge case: DST transition and rare timezones -->
 </gsl-test>
 
+<gsl-test id="T4">
+
+- T4: `obk trace-id` && `obk validate-today`
+</gsl-test>
+
+<gsl-test id="T5">
+
+- T5: `obk trace-id --timezone America/New_York` && `obk validate-today --timezone America/New_York`
+</gsl-test>
+
+<gsl-test id="T6">
+
+- T6: `obk harmonize-today --timezone Asia/Tokyo`
+</gsl-test>
+
 </gsl-tdd>
 
 <gsl-document-spec>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -309,3 +309,74 @@ def test_commands_any_directory(tmp_path):
         check=True,
     )
     assert (tmp_path / "prompts").exists()
+
+
+def _extract_ymd(text: str) -> str:
+    match = re.search(r"prompts/(\d{4})/(\d{2})/(\d{2})", text)
+    assert match
+    return "".join(match.groups())
+
+
+def test_today_commands_default_timezone(tmp_path):
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    trace = subprocess.run(
+        [sys.executable, "-m", "obk", "trace-id"],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    validate = subprocess.run(
+        [sys.executable, "-m", "obk", "validate-today"],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    harmonize = subprocess.run(
+        [sys.executable, "-m", "obk", "harmonize-today"],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    date = trace.stdout.strip()[:8]
+    assert date == _extract_ymd(validate.stdout)
+    assert date == _extract_ymd(harmonize.stdout)
+
+
+def test_today_commands_timezone_override(tmp_path):
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    tz = "America/New_York"
+    trace = subprocess.run(
+        [sys.executable, "-m", "obk", "trace-id", "--timezone", tz],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    validate = subprocess.run(
+        [sys.executable, "-m", "obk", "validate-today", "--timezone", tz],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    harmonize = subprocess.run(
+        [sys.executable, "-m", "obk", "harmonize-today", "--timezone", tz],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    date = trace.stdout.strip()[:8]
+    assert date == _extract_ymd(validate.stdout)
+    assert date == _extract_ymd(harmonize.stdout)


### PR DESCRIPTION
## Summary
- unify "today" prompt directory logic across commands using UTC by default
- support a new `--timezone/-tz` flag for `trace-id`, `validate-today`, and `harmonize-today`
- add automated tests covering default and overridden timezones

## Testing
- `pytest -q`
- `python -m obk validate-today --help | head -n 20`
- `python -m obk harmonize-today --help | head -n 20`
- `python -m obk trace-id --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688d7fbf86d48323b16491a327faaa89